### PR TITLE
add check for propolis bin on preflight

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -330,6 +330,14 @@ impl Runner {
 
     fn preflight(&self) -> Result<(), Error> {
 
+        // Verify all required executables are discoverable.
+        let out = Command::new(&self.propolis_binary).args(&["-V"]).output();
+        if out.is_err() {
+            return Err(Error::Exec(
+                format!("failed to find {} on PATH", &self.propolis_binary)
+            ))
+        }
+
         // ensure falcon working dir
         fs::create_dir_all(".falcon")?;
 


### PR DESCRIPTION
I was running into an error which didn't give me much of an idea of what was wrong:

```
rpz@kalm:~/oxidecomputer/falcon$ pfexec ./target/release/duo launch
Feb 09 16:33:22.006 INFO creating links
Feb 09 16:33:22.006 INFO creating simnet link 'duo_violin_sim0'
Feb 09 16:33:22.008 INFO creating vnic link 'duo_violin_vnic0'
Feb 09 16:33:22.008 INFO creating simnet link 'duo_piano_sim0'
Feb 09 16:33:22.009 INFO creating vnic link 'duo_piano_vnic0'
Feb 09 16:33:22.010 INFO creating external links
Feb 09 16:33:22.010 INFO creating nodes
No such file or directory (os error 2)
```

It would be nice to add an option to `info!` log all actions (somewhat like a `set -x` in shell), but an easier first step is to add more preflight checks. If the Falcon runner can't find the propolis binary there's no point in proceeding to launch.

After patch:

```
rpz@kalm:~/oxidecomputer/falcon$ pfexec ./target/release/duo launch                                                                       
Exec("failed to find propolis-server on PATH")        
```