### PR TITLE
allow FALCON_DATASET in environment to override root dataset

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -20,7 +20,7 @@ use tokio_tungstenite::tungstenite::Message;
 
 use clap::Parser;
 
-use crate::{error::Error, Deployment, Runner};
+use crate::{dataset, error::Error, Deployment, Runner};
 
 pub enum RunMode {
     Unspec,
@@ -324,10 +324,12 @@ fn snapshot(cmd: CmdSnapshot) -> Result<(), Error> {
         Some(node) => node,
     };
 
-    let source = format!("rpool/falcon/topo/{}/{}", d.name, node.name);
+    let dataset = dataset();
+
+    let source = format!("{}/topo/{}/{}", dataset, d.name, node.name);
     let source_snapshot = format!("{}@base", source);
 
-    let dest = format!("rpool/falcon/img/{}", cmd.snapshot_name,);
+    let dest = format!("{}/img/{}", dataset, cmd.snapshot_name,);
     let dest_snapshot = format!("{}@base", source);
 
     // first take a snapshot of the node clone

--- a/setup-base-images.sh
+++ b/setup-base-images.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+dataset=${FALCON_DATASET:-rpool/falcon}
+
 # Images follow the naming scheme
 #   <name>-<os_version>-<image_version>
 
@@ -22,12 +24,12 @@ for img in $images; do
     file=$img.raw
 
     name=${img%_*}
-    if [[ ! -b /dev/zvol/dsk/rpool/falcon/img/$name ]]; then
+    if [[ ! -b /dev/zvol/dsk/$dataset/img/$name ]]; then
         echo "Creating ZFS volume $name"
-        pfexec zfs create -p -V 20G rpool/falcon/img/$name
+        pfexec zfs create -p -V 20G "$dataset/img/$name"
         echo "Copying contents of image into volume"
-        pfexec dd if=$img.raw of=/dev/zvol/dsk/rpool/falcon/img/$name conv=sync 
+        pfexec dd if=$img.raw of="/dev/zvol/dsk/$dataset/img/$name" conv=sync
         echo "Creating base image snapshot"
-        pfexec zfs snapshot rpool/falcon/img/$name@base
+        pfexec zfs snapshot "$dataset/img/$name@base"
     fi
 done


### PR DESCRIPTION
As @andrewjstone and I were looking at using falcon under buildomat on the lab machine, it became apparent that `rpool/falcon` was hard-coded in a few places.  This PR seeks to allow the `FALCON_DATASET` environment variable to be set to override where we put things, so that we can create pools on devices other than the small ram-backed `rpool` that the buildomat `lab` target provides.