### PR TITLE
bump helios base image version

### DIFF
--- a/setup-base-images.sh
+++ b/setup-base-images.sh
@@ -11,7 +11,7 @@ echo "dataset is: $dataset"
 #
 # Old method of pulling statically defined images
 # TODO create new build pipelines for the following images
-images="debian-11.0_0 helios-1.1_0"
+images="debian-11.0_0 helios-1.2_0"
 mkdir -p .img
 pushd .img
 


### PR DESCRIPTION
The helios image has become quite out of date. I merged illumos mainline into the [falcon branch](https://github.com/oxidecomputer/illumos-gate/tree/falcon) and built a new helios-1.2 image based on a CI build of that branch.