### PR TITLE
[libfalcon] migrate to clap 4.0

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,7 +28,7 @@ libc = "0.2"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.14"
 futures = "0.3"
-clap = { version = "3.0.0-beta.5", features = ["color", "derive"] }
+clap = { version = "4.0.28", features = ["color", "derive"] }
 tabwriter = { version = "1", features = ["ansi_formatting"] }
 colored = "2"
 rand = "0.8"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
+use clap::ArgAction;
 use colored::*;
 use futures::{SinkExt, StreamExt};
 use propolis_client::{api::InstanceStateRequested, Client};
@@ -36,8 +37,8 @@ pub enum RunMode {
 #[clap(version = "0.1")]
 #[clap(infer_subcommands = true)]
 struct Opts {
-    #[clap(short, long, parse(from_occurrences))]
-    verbose: i32,
+    #[clap(short, long, action = ArgAction::Count)]
+    verbose: u8,
 
     #[clap(subcommand)]
     subcmd: SubCommand,


### PR DESCRIPTION
Just one change required, to switch to `ArgAction::Count`.
