### PR TITLE
add pfexec as a target runner

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,7 @@ LIBZFS_CORE_LOOKUP_WITH = "link"
 
 [net]
 git-fetch-with-cli = true
+
+# Set up pfexec as a target runner since tests always need to be run as root.
+[target.'cfg(target_os = "illumos")']
+runner = "pfexec"

--- a/README.md
+++ b/README.md
@@ -100,9 +100,12 @@ This assumes that that the instructions in the install section have been run.
 
 ```
 cargo build
-pfexec cargo test -- --test-threads 1
-pfexec cargo test -- --test-threads 1 --ignored
+cargo test -- --test-threads 1
+cargo test -- --test-threads 1 --ignored
 ```
+
+Note that `cargo test` will automatically use `pfexec` to run tests; this is configured in
+[.cargo/config.toml](.cargo/config.toml).
 
 Due to a shared `.falcon` directory, concurrent tests are not possible at the
 current time.


### PR DESCRIPTION
All of the tests in this repo require pfexec, so just use that here. (It's nice that pfexec doesn't cause a user prompt, which would be problematic most likely).

In the future it would be cool to have some filtering of target runner by test name (maybe I should add that to nextest?)