### PR TITLE
Add support for host to softnpu port loopbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Set up propolis, firmware and OS base images.
 ```
 
 Falcon-enabled propolis builds are kicked out by Propolis CI. See
-[this run](https://github.com/oxidecomputer/propolis/runs/11409835734)
+[this run](https://github.com/oxidecomputer/propolis/runs/18227942372)
 as an example.
 
 ## QuickStart

--- a/get-propolis.sh
+++ b/get-propolis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-curl -OL https://buildomat.eng.oxide.computer/wg/0/artefact/01HBEK1VP0XXQ5AGHQWG4VHHKC/fhGuUKZ1HmugHzQGV0IQIHDlOxLHCMAN9A5GfwxxywEiL6bc/01HBEK24DF8XE8XGTR2BGDPVXD/01HBEKT35XJM7PMK471A2FV2KM/propolis-server
+curl -OL https://buildomat.eng.oxide.computer/wg/0/artefact/01HE32FGWQ0PVSJN8A4R7MD06C/Mah1dCoejq19niYXlNIsmhds9lSKf62PyuO8SG9NP5SQQPRG/01HE32FS8F8W1ZAEPV8AKZ5JWW/01HE336NXE027YQC4380PY6WWR/propolis-server
 chmod +x propolis-server
 pfexec mv propolis-server /usr/bin/

--- a/setup-base-images.sh
+++ b/setup-base-images.sh
@@ -40,5 +40,3 @@ for img in $images; do
 done
 
 popd
-
-./get-netstack.sh


### PR DESCRIPTION
This PR adds support for connecting a VM with a softnpu device to one of the ports of that softnpu device (e.g. connect a host port to one of its own softnpu ASIC ports). This is needed for faithfully representing Oxide racks.