### PR TITLE
Tweak image import script

### DIFF
--- a/setup-base-images.sh
+++ b/setup-base-images.sh
@@ -31,9 +31,9 @@ for img in $images; do
     name=${img%_*}
     if [[ ! -b /dev/zvol/dsk/$dataset/img/$name ]]; then
         echo "Creating ZFS volume $name"
-        pfexec zfs create -p -V 20G "$dataset/img/$name"
+        pfexec zfs create -p -V 20G -o volblocksize=4k "$dataset/img/$name"
         echo "Copying contents of image into volume"
-        pfexec dd if=$img.raw of="/dev/zvol/dsk/$dataset/img/$name" conv=sync
+        pfexec dd if=$img.raw of="/dev/zvol/rdsk/$dataset/img/$name" bs=1024k status=progress
         echo "Creating base image snapshot"
         pfexec zfs snapshot "$dataset/img/$name@base"
     fi


### PR DESCRIPTION
Explicitly setting the zvol blocksize to 4k will avoid RMW (assuming 4k blocks are exposed to the guests).  Additionally, synchronous writes during image import are not required