### PR TITLE
smaller base images, configurable snapshot sizes

### DIFF
--- a/setup-base-images.sh
+++ b/setup-base-images.sh
@@ -40,7 +40,9 @@ for img in $images; do
     fi
     if [[ ! -b /dev/zvol/dsk/$dataset/img/$name ]]; then
         echo "Creating ZFS volume $name"
-        pfexec zfs create -p -V 100G -o volblocksize=4k "$dataset/img/$name"
+        fsize=`stat --format "%s" $img.raw`
+        let vsize=(fsize + 4096 - size%4096)
+        pfexec zfs create -p -V $vsize -o volblocksize=4k "$dataset/img/$name"
         echo "Copying contents of image into volume"
         pfexec dd if=$img.raw of="/dev/zvol/rdsk/$dataset/img/$name" bs=1024k status=progress
         echo "Creating base image snapshot"


### PR DESCRIPTION
Previously, base images were set to 100G by default, which is wasteful. We can start with a small base image and a corresponding base image snapshot. Then, make clones of the snapshots and adjust them to the desired size. 

A new field is exposed on node structures to set image size in the topology description.

The snapshot clones that underpin VMs now pre-reserve capacity for zfs volumes. This is an effort to fail early for lack of capacity, rather than when a topology is running.