### PR TITLE
add indicator for console quit sequence

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -406,6 +406,12 @@ fn destroy(r: &Runner) {
 }
 
 async fn console(name: &str) -> Result<(), Error> {
+    println!(
+        "{}\n{}\n{}",
+        "Entering VM console.".blue(),
+        "Use ^q to exit.".bright_blue(),
+        "Press enter to continue.".bright_blue()
+    );
     let port: u16 = fs::read_to_string(format!(".falcon/{}.port", name))?
         .trim_end()
         .parse()?;

--- a/setup-base-images.sh
+++ b/setup-base-images.sh
@@ -36,7 +36,7 @@ for img in $images; do
     name=${img%_*}
     if [[ $FORCE == 1 ]]; then
         echo "Deleting $name image"
-        pfexec zfs destroy -r $dataset/img/$name
+        pfexec zfs destroy -r $dataset/img/$name || true
     fi
     if [[ ! -b /dev/zvol/dsk/$dataset/img/$name ]]; then
         echo "Creating ZFS volume $name"


### PR DESCRIPTION
We now provide a console escape indicator

```
ry@masaka:/space/testbed/a4x2$ ./a4x2 serial g2
Entering VM console.
Use ^q to exit.
Press enter to continue.
```