### PR TITLE
image import script fixups

### DIFF
--- a/import-raw-img.sh
+++ b/import-raw-img.sh
@@ -20,7 +20,7 @@ fi
 if [[ ! -b /dev/zvol/dsk/$dataset/img/$name ]]; then
     echo "Creating ZFS volume $name"
     fsize=`stat --format "%s" $file`
-    let vsize=$((fsize + 4096 - ( fsize % 4096 ) ))
+    (( vsize = fsize + 4096 - ( fsize % 4096 ) ))
     pfexec zfs create -p -V $vsize -o volblocksize=4k "$dataset/img/$name"
     echo "Copying contents of image into volume"
     pfexec dd if=$file of="/dev/zvol/rdsk/$dataset/img/$name" bs=1024k status=progress

--- a/import-raw-img.sh
+++ b/import-raw-img.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-set -e
-set -x
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
 
 dataset=${FALCON_DATASET:-rpool/falcon}
 
@@ -13,7 +15,7 @@ fi
 file=$1
 name=$2
 
-if [[ $FORCE == 1 ]]; then
+if [[ -n "${FORCE+x}" ]]; then
     echo "Deleting $name image"
     pfexec zfs destroy -r $dataset/img/$name || true
 fi

--- a/import-raw-img.sh
+++ b/import-raw-img.sh
@@ -20,7 +20,7 @@ fi
 if [[ ! -b /dev/zvol/dsk/$dataset/img/$name ]]; then
     echo "Creating ZFS volume $name"
     fsize=`stat --format "%s" $file`
-    let vsize=(fsize + 4096 - size%4096)
+    let vsize=$((fsize + 4096 - ( fsize % 4096 ) ))
     pfexec zfs create -p -V $vsize -o volblocksize=4k "$dataset/img/$name"
     echo "Copying contents of image into volume"
     pfexec dd if=$file of="/dev/zvol/rdsk/$dataset/img/$name" bs=1024k status=progress

--- a/setup-base-images.sh
+++ b/setup-base-images.sh
@@ -20,7 +20,7 @@ pushd .img
 for img in $images; do
     name=${img%_*}
     file=$img.raw.xz
-    if [[ $FORCE == 1 ]]; then
+    if [[ -n "${FORCE+x}" ]]; then
         rm -f $file
         rm -rf $img.raw
         echo "Deleting $name image"

--- a/setup-base-images.sh
+++ b/setup-base-images.sh
@@ -20,7 +20,14 @@ for img in $images; do
     if [[ $FORCE == 1 ]]; then
         rm -f $file
         rm -rf $img.raw
+        echo "Deleting $name image"
+        pfexec zfs destroy -r $dataset/img/$name || true
     fi
+
+    if [[ -b /dev/zvol/dsk/$dataset/img/$name ]]; then
+        continue
+    fi
+
     if [[ ! -f $file ]]; then
         echo "Pulling $file"
         echo "https://oxide-falcon-assets.s3.us-west-2.amazonaws.com/$file"
@@ -32,22 +39,15 @@ for img in $images; do
     fi
     file=$img.raw
 
-
     name=${img%_*}
-    if [[ $FORCE == 1 ]]; then
-        echo "Deleting $name image"
-        pfexec zfs destroy -r $dataset/img/$name || true
-    fi
-    if [[ ! -b /dev/zvol/dsk/$dataset/img/$name ]]; then
-        echo "Creating ZFS volume $name"
-        fsize=`stat --format "%s" $img.raw`
-        let vsize=(fsize + 4096 - size%4096)
-        pfexec zfs create -p -V $vsize -o volblocksize=4k "$dataset/img/$name"
-        echo "Copying contents of image into volume"
-        pfexec dd if=$img.raw of="/dev/zvol/rdsk/$dataset/img/$name" bs=1024k status=progress
-        echo "Creating base image snapshot"
-        pfexec zfs snapshot "$dataset/img/$name@base"
-    fi
+    echo "Creating ZFS volume $name"
+    fsize=`stat --format "%s" $img.raw`
+    let vsize=$((fsize + 4096 - ( fsize % 4096 ) ))
+    pfexec zfs create -p -V $vsize -o volblocksize=4k "$dataset/img/$name"
+    echo "Copying contents of image into volume"
+    pfexec dd if=$img.raw of="/dev/zvol/rdsk/$dataset/img/$name" bs=1024k status=progress
+    echo "Creating base image snapshot"
+    pfexec zfs snapshot "$dataset/img/$name@base"
 done
 
 popd


### PR DESCRIPTION
- only download images if we're actually going to install them ( resolve #94 )
- change vol size calculation syntax to allow shellcheck to check it
- fix a minor logic bug in zvol size calculation from using a non-existent variable (thanks shellcheck!)
- add `-o nounset` to make using non-existent variables an error
- update FORCE check to work in the presence of `-o nounset`
  - Note I've done it in a way that changes behavior so `FORCE=<any string>` will force. `FORCE=1`, `FORCE=y`, `FORCE=jabberwocky`, etc.
- add `-o pipefail` out of habit

I haven't actually executed `import-raw-img.sh`, just ported changes over as I made them to `setup-base-images.sh`. I have tested `setup-base-images.sh` though.