### PR TITLE
Fix test failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino-tempfile"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb905055fa81e4d427f919b2cd0d76a998267de7d225ea767a1894743a5263c2"
+dependencies = [
+ "camino",
+ "tempfile",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +987,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "camino",
+ "camino-tempfile",
  "clap",
  "colored",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ reqwest = "0.12.7"
 oxnet = { version = "0.1.0", default-features = false }
 indicatif = "0.17.8"
 xz2 = "0.1.7"
+camino-tempfile = "1.1.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -35,3 +35,6 @@ reqwest.workspace = true
 indicatif.workspace = true
 xz2.workspace = true
 anstyle = "1.0.4"
+
+[dev-dependencies]
+camino-tempfile.workspace = true

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -292,6 +292,11 @@ impl Runner {
         }
     }
 
+    pub fn set_falcon_dir(&mut self, dir: &Utf8Path) {
+        self.falcon_dir = dir.to_string().into();
+        info!(self.log, "set falcon dir to {}", self.falcon_dir);
+    }
+
     /// Create a new node within this deployment with the given name. Names must
     /// conform to `[A-Za-z]?[A-Za-z0-9_]*`
     pub fn node(
@@ -648,7 +653,7 @@ impl Runner {
             .output()?;
 
         // Destroy workspace
-        info!(self.log, "destroying workspace");
+        info!(self.log, "destroying workspace at {}", self.falcon_dir);
         fs::remove_dir_all(&self.falcon_dir)?;
 
         Ok(())
@@ -1561,7 +1566,7 @@ pub(crate) async fn launch_vm(
     fs::write(&path, child.id().to_string())?;
     path.pop();
 
-    let port = find_propolis_port_in_log(format!(".falcon/{}.out", node.name))
+    let port = find_propolis_port_in_log(format!("{}/{}.out", falcon_dir, node.name))
         .await
         .map_err(|e| anyhow::anyhow!("find propolis port in log: {e}"))?;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1566,9 +1566,10 @@ pub(crate) async fn launch_vm(
     fs::write(&path, child.id().to_string())?;
     path.pop();
 
-    let port = find_propolis_port_in_log(format!("{}/{}.out", falcon_dir, node.name))
-        .await
-        .map_err(|e| anyhow::anyhow!("find propolis port in log: {e}"))?;
+    let port =
+        find_propolis_port_in_log(format!("{}/{}.out", falcon_dir, node.name))
+            .await
+            .map_err(|e| anyhow::anyhow!("find propolis port in log: {e}"))?;
 
     path.push(format!("{}.port", node.name));
     fs::write(&path, port.to_string())?;

--- a/lib/src/test.rs
+++ b/lib/src/test.rs
@@ -12,6 +12,11 @@ use anyhow::{anyhow, Result};
 #[tokio::test]
 async fn empty_launch() -> Result<()> {
     let mut d = crate::Runner::new("empty_launch");
+
+    // Each test must use a separate falcon dir
+    let falcon_dir = camino_tempfile::tempdir()?;
+    d.set_falcon_dir(&falcon_dir.path());
+
     d.persistent = true;
     d.launch().await?;
     d.destroy()?;
@@ -25,6 +30,11 @@ async fn empty_launch() -> Result<()> {
 #[tokio::test]
 async fn solo_launch() -> Result<()> {
     let mut d = crate::Runner::new("solo");
+
+    // Each test must use a separate falcon dir
+    let falcon_dir = camino_tempfile::tempdir()?;
+    d.set_falcon_dir(&falcon_dir.path());
+
     let z = d.node("violin", "helios-2.5", 1, 1024);
 
     // mount a file into the node
@@ -54,13 +64,18 @@ async fn duo_launch() -> Result<()> {
     // These are the links we'll expect to see, one simnet and one vnic for
     // each node
     let links = [
-        String::from("duo_violin_sim0"),
-        String::from("duo_violin_vnic0"),
-        String::from("duo_piano_sim0"),
-        String::from("duo_piano_vnic0"),
+        String::from("duo_violin_vn_sim0"),
+        String::from("duo_violin_vn_vnic0"),
+        String::from("duo_piano_vn_sim0"),
+        String::from("duo_piano_vn_vnic0"),
     ];
 
     let mut d = crate::Runner::new("duo");
+
+    // Each test must use a separate falcon dir
+    let falcon_dir = camino_tempfile::tempdir()?;
+    d.set_falcon_dir(&falcon_dir.path());
+
     let violin = d.node("violin", "helios-2.5", 1, 1024);
     let piano = d.node("piano", "helios-2.5", 1, 1024);
     d.link(violin, piano);


### PR DESCRIPTION
- each test deployment must specify a tempdir as their falcon directory
- fix a hard-coded '.falcon' path
- update vnic names