### PR TITLE
Allow consumers of libfalcon to add commands

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -73,7 +73,7 @@ enum SubCommand<T: clap::Args> {
     #[clap(about = "execute a command on a node")]
     Exec(CmdExec),
     /// Allow users of this library to add their own set of commands
-    #[clap(about = "optional extra commands")]
+    #[clap(about = "topology-specific commands")]
     Extra(T),
 }
 


### PR DESCRIPTION
Users of libfalcon may now add topology-specific commands, and those will be presented under a 'extra' subcommand.