### PR TITLE
Build an instance spec for the latest propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,7 +235,11 @@ version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
  "num-traits",
+ "serde",
+ "windows-link",
 ]
 
 [[package]]
@@ -292,23 +311,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "cpuid_profile_config"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fae5334bcad5e864794332c6fed5e6bb9ec88831#fae5334bcad5e864794332c6fed5e6bb9ec88831"
-dependencies = [
- "serde",
- "serde_derive",
- "thiserror 1.0.69",
- "toml",
 ]
 
 [[package]]
@@ -325,6 +339,25 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crucible-client-types"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/crucible?rev=da3cf198a0e000bb89efc3a1c77d7ba09340a600#da3cf198a0e000bb89efc3a1c77d7ba09340a600"
+dependencies = [
+ "base64 0.22.1",
+ "crucible-workspace-hack",
+ "schemars",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "crucible-workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd293370c6cb9c334123675263de33fc9e53bbdfc8bdd5e329237cf0205fdc7"
 
 [[package]]
 name = "crypto-common"
@@ -347,6 +380,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -655,6 +724,12 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -689,6 +764,12 @@ name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -785,6 +866,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -906,6 +1011,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,12 +1039,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -1030,7 +1152,6 @@ dependencies = [
  "libc",
  "libnet",
  "propolis-client",
- "propolis-server-config",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -1232,7 +1353,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc02deea53ffe807708244e5914f6b099ad7015a207ee24317c22112e17d9c5c"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "serde",
  "serde_json",
 ]
@@ -1361,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "progenitor"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293df5b79211fbf0c1ebad6513ba451d267e9c15f5f19ee5d3da775e2dd27331"
+checksum = "88f54bd2506c3e7b6e45b6ab16500abef551689021264f3be260ef7e295ac327"
 dependencies = [
  "progenitor-client",
  "progenitor-impl",
@@ -1372,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "progenitor-client"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a5db54eac3cae7007a0785854bc3e89fd418cca7dfc2207b99b43979154c1b"
+checksum = "fdae8df95f0b2a7d6159a9c43b7380016b8d3b0fc1ece46871ecd2e0087cfaf6"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1387,13 +1508,13 @@ dependencies = [
 
 [[package]]
 name = "progenitor-impl"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85934a440963a69f9f04f48507ff6e7aa2952a5b2d8f96cc37fa3dd5c270f66"
+checksum = "37adc80a94c9cae890e82deeeecc9d8f2a5cb153256caaf1bf0f03611e537214"
 dependencies = [
  "heck 0.5.0",
  "http",
- "indexmap",
+ "indexmap 2.9.0",
  "openapiv3",
  "proc-macro2",
  "quote",
@@ -1402,16 +1523,16 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.100",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "typify",
  "unicode-ident",
 ]
 
 [[package]]
 name = "progenitor-macro"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99a5a259e2d65a4933054aa51717c70b6aba0522695731ac354a522124efc9b"
+checksum = "fc3b2b9f0d5ba58375c5e8e89d5dff949108e234c1d9f22a3336d2be4daaf292"
 dependencies = [
  "openapiv3",
  "proc-macro2",
@@ -1428,12 +1549,15 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fae5334bcad5e864794332c6fed5e6bb9ec88831#fae5334bcad5e864794332c6fed5e6bb9ec88831"
+source = "git+https://github.com/oxidecomputer/propolis?rev=ba4d338f0c98faa0328502c99aa6fa0e0948d3da#ba4d338f0c98faa0328502c99aa6fa0e0948d3da"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
+ "crucible-client-types",
  "futures",
  "progenitor",
+ "progenitor-client",
+ "propolis_api_types",
  "rand 0.8.5",
  "reqwest",
  "schemars",
@@ -1447,15 +1571,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "propolis-server-config"
+name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fae5334bcad5e864794332c6fed5e6bb9ec88831#fae5334bcad5e864794332c6fed5e6bb9ec88831"
+source = "git+https://github.com/oxidecomputer/propolis?rev=ba4d338f0c98faa0328502c99aa6fa0e0948d3da#ba4d338f0c98faa0328502c99aa6fa0e0948d3da"
 dependencies = [
- "cpuid_profile_config",
+ "crucible-client-types",
+ "propolis_types",
+ "schemars",
  "serde",
- "serde_derive",
+ "serde_with",
  "thiserror 1.0.69",
- "toml",
+ "uuid",
+]
+
+[[package]]
+name = "propolis_types"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/propolis?rev=ba4d338f0c98faa0328502c99aa6fa0e0948d3da#ba4d338f0c98faa0328502c99aa6fa0e0948d3da"
+dependencies = [
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -1642,7 +1777,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ef7fa9ed0256d64a688a3747d0fef7a88851c18a5e1d57f115f38ec2e09366"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
  "memchr",
 ]
 
@@ -1934,12 +2069,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.9.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -2378,7 +2543,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2391,7 +2556,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "toml_datetime",
  "winnow 0.7.4",
 ]
@@ -2487,9 +2652,9 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typify"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c644dda9862f0fef3a570d8ddb3c2cfb1d5ac824a1f2ddfa7bc8f071a5ad8a"
+checksum = "e03ba3643450cfd95a1aca2e1938fef63c1c1994489337998aff4ad771f21ef8"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -2497,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ab345b6c0d8ae9500b9ff334a4c7c0d316c1c628dc55726b95887eb8dbd11"
+checksum = "bce48219a2f3154aaa2c56cbf027728b24a3c8fe0a47ed6399781de2b3f3eeaf"
 dependencies = [
  "heck 0.5.0",
  "log",
@@ -2511,15 +2676,15 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.100",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "unicode-ident",
 ]
 
 [[package]]
 name = "typify-macro"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785e2cdcef0df8160fdd762ed548a637aaec1e83704fdbc14da0df66013ee8d0"
+checksum = "68b5780d745920ed73c5b7447496a9b5c42ed2681a9b70859377aec423ecf02b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2767,6 +2932,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,7 +2979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -2797,6 +2997,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,7 @@ slog = { version = "2.7", features = ["max_level_trace"] }
 slog-term = "2.7"
 slog-async = "2.7"
 slog-envlogger = "2.2"
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
-propolis-server-config = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "ba4d338f0c98faa0328502c99aa6fa0e0948d3da" }
 toml = "0.7"
 libc = "0.2"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/get-propolis.sh
+++ b/get-propolis.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-curl -OL https://buildomat.eng.oxide.computer/wg/0/artefact/01J8TPA802A5SHWPY5K05ZH2J3/ucXqZK2nT2qxxgI0vY5iygOCdEwguBoe9fk3cFrm4IOs9TLX/01J8TPAVRJDHEYKPEG07AHG51H/01J8TQ0QB5M510N99RWD7X55HT/propolis-server
+# from propolis' `falcon` job, commit ba4d338f0c98faa0328502c99aa6fa0e0948d3da
+curl -OL https://buildomat.eng.oxide.computer/wg/0/artefact/01JQA00H3HQ2H7JW0PWMDQ7XDN/52rIztYQlpRJEttYOMaflSu2b8GnmLPUnW6TsjkChj37dvgp/01JQA00TDFWX2870391FPKBY76/01JQA0N556K971D0XGQPGJYVKJ/propolis-server
 chmod +x propolis-server
 pfexec mv propolis-server /usr/bin/

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,7 +20,6 @@ slog-term.workspace = true
 slog-async.workspace = true
 slog-envlogger.workspace = true
 propolis-client.workspace = true
-propolis-server-config.workspace = true
 toml.workspace = true
 libc.workspace = true
 tokio.workspace = true

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -357,13 +357,13 @@ fn info(r: &Runner) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn preflight(r: &Runner) {
+async fn preflight(r: &mut Runner) {
     if let Err(e) = r.preflight().await {
         eprintln!("error: {}", e)
     }
 }
 
-async fn launch(r: &Runner) {
+async fn launch(r: &mut Runner) {
     if let Err(e) = r.launch().await {
         eprintln!("error: {}", e)
     }
@@ -718,7 +718,8 @@ async fn hyperstart(
     path.pop();
     let log = create_logger();
 
-    crate::launch_vm(&log, &propolis_binary, &id, node, falcon_dir).await?;
+    crate::launch_vm(&log, &propolis_binary, &id, node, falcon_dir, None)
+        .await?;
 
     Ok(())
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -19,26 +19,35 @@ use error::Error;
 use futures::future::join_all;
 use futures::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
-use propolis_client::types::InstanceMetadata;
-use propolis_server_config::{BlockDevice, BlockOpts, Device};
 use ron::ser::{to_string_pretty, PrettyConfig};
 use serde::{Deserialize, Serialize};
 use slog::Drain;
 use slog::{debug, error, info, warn, Logger};
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fs::{self, OpenOptions};
 use std::io::BufWriter;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::os::unix::fs::MetadataExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use std::str::FromStr;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::time::{sleep, Duration, Instant};
+use uuid::Uuid;
 use xz2::read::XzDecoder;
+
+use propolis_client::types::InstanceMetadata;
+use propolis_client::types::{
+    ComponentV0, DlpiNetworkBackend, FileStorageBackend, P9fs, SerialPort,
+    SerialPortNumber, SoftNpuP9, SoftNpuPciPort, SoftNpuPort, VirtioDisk,
+    VirtioNetworkBackend, VirtioNic,
+};
+use propolis_client::PciPath;
+use propolis_client::SpecKey;
 
 #[macro_export]
 macro_rules! node {
@@ -166,6 +175,8 @@ pub struct Node {
     pub primary_disk_backing: PrimaryDiskBacking,
     /// VNC port to use
     pub vnc_port: Option<u16>,
+    /// Propolis components for instance spec
+    pub components: BTreeMap<SpecKey, ComponentV0>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -320,6 +331,7 @@ impl Runner {
             reserved: 20,
             primary_disk_backing: PrimaryDiskBacking::Zvol,
             vnc_port: None,
+            components: BTreeMap::new(),
         };
         self.deployment.nodes.push(n);
         r
@@ -508,7 +520,7 @@ impl Runner {
     /// the propolis VM instances, create the point to point network interfaces,
     /// set up the serial console for each VM and, run any user defined exec
     /// statements.
-    pub async fn launch(&self) -> Result<(), Error> {
+    pub async fn launch(&mut self) -> Result<(), Error> {
         self.preflight().await?;
         match self.do_launch().await {
             Ok(()) => Ok(()),
@@ -519,7 +531,7 @@ impl Runner {
         }
     }
 
-    async fn preflight(&self) -> Result<(), Error> {
+    async fn preflight(&mut self) -> Result<(), Error> {
         // Verify all required executables are discoverable.
         let out = Command::new(&self.propolis_binary).args(["-V"]).output();
         if out.is_err() {
@@ -539,9 +551,7 @@ impl Runner {
         topo_path.push("topology.ron");
         fs::write(&topo_path, out)?;
 
-        for n in self.deployment.nodes.iter() {
-            n.preflight(self).await?;
-        }
+        self.deployment.nodes_preflight(&self.log).await?;
 
         Ok(())
     }
@@ -703,6 +713,51 @@ impl Deployment {
             e.index,
         )
     }
+
+    async fn nodes_preflight(&mut self, log: &Logger) -> Result<(), Error> {
+        let mut endpoints = Vec::new();
+        for l in &self.links {
+            endpoints.extend_from_slice(&l.endpoints);
+        }
+        for l in &self.ext_links {
+            endpoints.push(l.endpoint.clone());
+        }
+
+        let mut node_endpoints_map: HashMap<String, Vec<NodeEndpoint>> =
+            HashMap::new();
+        let mut softnpu_deployment = false;
+
+        for n in self.nodes.iter() {
+            let node_endpoints: Vec<NodeEndpoint> = endpoints
+                .iter()
+                .filter(|e| self.nodes[e.node.index].name == n.name)
+                .map(|e| NodeEndpoint {
+                    vnic_name: self.vnic_link_name(e),
+                    endpoint: e.clone(),
+                })
+                .collect();
+
+            let has_softnpu = node_endpoints.iter().any(|ne| {
+                matches!(&ne.endpoint.kind, EndpointKind::SoftNPU(_))
+            });
+
+            softnpu_deployment |= has_softnpu;
+
+            node_endpoints_map.insert(n.name.clone(), node_endpoints);
+        }
+
+        for n in self.nodes.iter_mut() {
+            n.preflight(
+                log,
+                &self.name,
+                &node_endpoints_map[&n.name],
+                softnpu_deployment,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
 }
 
 impl Drop for Runner {
@@ -716,161 +771,142 @@ impl Drop for Runner {
     }
 }
 
-impl Node {
-    async fn preflight(&self, r: &Runner) -> Result<(), Error> {
-        let mut devices = BTreeMap::new();
-        let mut block_devs = BTreeMap::new();
+struct NodeEndpoint {
+    vnic_name: String,
+    endpoint: Endpoint,
+}
 
-        self.try_ensure_base_image(&r.log).await?;
+impl Node {
+    async fn preflight(
+        &mut self,
+        log: &Logger,
+        deployment_name: &str,
+        node_endpoints: &[NodeEndpoint],
+        softnpu_deployment: bool,
+    ) -> Result<(), Error> {
+        self.try_ensure_base_image(log).await?;
+
+        self.components.insert(
+            SpecKey::Name("com1".into()),
+            ComponentV0::SerialPort(SerialPort {
+                num: SerialPortNumber::Com1,
+            }),
+        );
 
         let backing = match self.primary_disk_backing {
-            PrimaryDiskBacking::Zvol => self.create_zvol_backing(r)?,
-            PrimaryDiskBacking::File => self.create_file_backing(r)?,
+            PrimaryDiskBacking::Zvol => {
+                self.create_zvol_backing(deployment_name)?
+            }
+            PrimaryDiskBacking::File => {
+                self.create_file_backing(log, deployment_name)?
+            }
         };
-        self.create_blockdev(backing, &mut devices, &mut block_devs);
+        self.create_blockdev(backing);
 
         let mut pci_index = 5;
 
         // mounts
         for (i, m) in self.mounts.iter().enumerate() {
-            let mut opts = BTreeMap::new();
-            opts.insert("source".to_string(), m.source.to_string().into());
-            opts.insert("target".to_string(), m.destination.to_string().into());
-            opts.insert(
-                "pci-path".to_string(),
-                toml::Value::String(format!("0.{}.0", pci_index)),
+            self.components.insert(
+                SpecKey::Name(format!("fs{i}")),
+                ComponentV0::P9fs(P9fs {
+                    source: m.source.to_string(),
+                    target: m.destination.to_string(),
+                    chunk_size: 65536, // XXX magic number?
+                    pci_path: PciPath::new(0, pci_index, 0).unwrap(),
+                }),
             );
 
-            devices.insert(
-                format!("fs{}", i),
-                propolis_server_config::Device {
-                    driver: "pci-virtio-9p".to_string(),
-                    options: opts,
-                },
-            );
             pci_index += 1;
         }
 
         // network interfaces
-        let d = &r.deployment;
 
-        //let mut links: Vec<String> = Vec::new();
         let mut viona_index = 0;
         let mut softnpu_index = 0;
 
-        let mut endpoints = Vec::new();
-        for l in &d.links {
-            endpoints.extend_from_slice(&l.endpoints);
-        }
-        for l in &d.ext_links {
-            endpoints.push(l.endpoint.clone());
-        }
-
-        let has_softnpu = endpoints
-            .iter()
-            .any(|x| matches!(&x.kind, EndpointKind::SoftNPU(_)));
-
-        if has_softnpu {
-            let mut opts = BTreeMap::new();
-            opts.insert(
-                "pci-path".to_string(),
-                toml::Value::String(format!("0.{}.0", pci_index)),
+        // if using a softnpu deployment, each instance must have the following
+        // components, but note that the spec keys will (current) be overwritten
+        // by propolis-server
+        if softnpu_deployment {
+            self.components.insert(
+                SpecKey::Name("softnpu-p9".into()),
+                ComponentV0::SoftNpuP9(SoftNpuP9 {
+                    pci_path: PciPath::new(0, pci_index, 0).unwrap(),
+                }),
             );
 
-            devices.insert(
-                "softnpup9".to_owned(),
-                propolis_server_config::Device {
-                    driver: "softnpu-p9".to_string(),
-                    options: opts,
-                },
-            );
             pci_index += 1;
 
-            let mut opts = BTreeMap::new();
-            opts.insert(
-                "pci-path".to_string(),
-                toml::Value::String(format!("0.{}.0", pci_index)),
+            self.components.insert(
+                SpecKey::Name("softnpu-pci-port".into()),
+                ComponentV0::SoftNpuPciPort(SoftNpuPciPort {
+                    pci_path: PciPath::new(0, pci_index, 0).unwrap(),
+                }),
             );
 
-            devices.insert(
-                "softnpu-pci-port".to_owned(),
-                propolis_server_config::Device {
-                    driver: "softnpu-pci-port".to_string(),
-                    options: opts,
-                },
-            );
             pci_index += 1;
+
+            // note: softnpu requires com4 but propolis-server will add that for
+            // us
         }
 
-        for e in &endpoints {
-            if d.nodes[e.node.index].name == self.name {
-                match &e.kind {
-                    EndpointKind::Viona(_) => {
-                        //links.push(d.vnic_link_name(e));
-                        let mut opts = BTreeMap::new();
-                        opts.insert(
-                            "vnic".to_string(),
-                            toml::Value::String(d.vnic_link_name(e)),
-                        );
-                        opts.insert(
-                            "pci-path".to_string(),
-                            toml::Value::String(format!("0.{}.0", pci_index)),
-                        );
-                        devices.insert(
-                            format!("net{}", viona_index),
-                            propolis_server_config::Device {
-                                driver: "pci-virtio-viona".to_string(),
-                                options: opts,
+        for NodeEndpoint {
+            vnic_name,
+            endpoint,
+        } in node_endpoints
+        {
+            match &endpoint.kind {
+                EndpointKind::Viona(_) => {
+                    self.components.insert(
+                        SpecKey::Name(format!("net{viona_index}-backing")),
+                        ComponentV0::VirtioNetworkBackend(
+                            VirtioNetworkBackend {
+                                vnic_name: vnic_name.clone(),
                             },
-                        );
-                        viona_index += 1;
-                        pci_index += 1;
-                    }
+                        ),
+                    );
 
-                    EndpointKind::SoftNPU(mac) => {
-                        let mut opts = BTreeMap::new();
-                        opts.insert(
-                            "vnic".to_string(),
-                            toml::Value::String(d.vnic_link_name(e)),
-                        );
-                        if let Some(ref mac) = mac {
-                            opts.insert(
-                                "mac".to_string(),
-                                toml::Value::String(mac.clone()),
-                            );
-                        };
-                        devices.insert(
-                            format!("port{}", softnpu_index),
-                            propolis_server_config::Device {
-                                driver: "softnpu-port".to_string(),
-                                options: opts,
-                            },
-                        );
-                        softnpu_index += 1;
-                    }
+                    self.components.insert(
+                        SpecKey::Name(format!("net{viona_index}")),
+                        ComponentV0::VirtioNic(VirtioNic {
+                            backend_id: SpecKey::Name(format!(
+                                "net{viona_index}-backing"
+                            )),
+                            interface_id: Uuid::new_v4(),
+                            pci_path: PciPath::new(0, pci_index, 0).unwrap(),
+                        }),
+                    );
+
+                    viona_index += 1;
+                    pci_index += 1;
+                }
+
+                // XXX is mac used in spec?
+                EndpointKind::SoftNPU(_mac) => {
+                    let backend_id = SpecKey::Name(format!(
+                        "softnpu{softnpu_index}-backing"
+                    ));
+
+                    self.components.insert(
+                        backend_id.clone(),
+                        ComponentV0::DlpiNetworkBackend(DlpiNetworkBackend {
+                            vnic_name: vnic_name.clone(),
+                        }),
+                    );
+
+                    self.components.insert(
+                        SpecKey::Name(format!("softnpu{softnpu_index}-port")),
+                        ComponentV0::SoftNpuPort(SoftNpuPort {
+                            link_name: format!("softnpu{softnpu_index}"),
+                            backend_id,
+                        }),
+                    );
+
+                    softnpu_index += 1;
                 }
             }
         }
-
-        let chipset = propolis_server_config::Chipset {
-            options: BTreeMap::new(),
-        };
-
-        // write propolis instance config to <falcon_dir>/<node-name>.toml
-
-        let propolis_config = propolis_server_config::Config {
-            bootrom: PathBuf::from("/var/ovmf/OVMF_CODE.fd"),
-            chipset,
-            devices,
-            block_devs,
-            ..Default::default()
-        };
-
-        let config_toml = toml::to_string(&propolis_config)?;
-
-        let mut path = r.falcon_dir.clone();
-        path.push(format!("{}.toml", self.name));
-        fs::write(&path, config_toml)?;
 
         Ok(())
     }
@@ -1076,15 +1112,16 @@ impl Node {
         Ok(())
     }
 
-    fn create_zvol_backing(&self, r: &Runner) -> Result<String, Error> {
+    fn create_zvol_backing(
+        &self,
+        deployment_name: &str,
+    ) -> Result<String, Error> {
         //Clone base image
 
         //TODO incorporate version into img
         let source = format!("{}/img/{}@base", self.dataset, self.image);
-        let dest = format!(
-            "{}/topo/{}/{}",
-            self.dataset, r.deployment.name, self.name
-        );
+        let dest =
+            format!("{}/topo/{}/{}", self.dataset, deployment_name, self.name);
 
         let out = Command::new(ZFS_BIN)
             .args(["clone", "-p", source.as_ref(), dest.as_ref()])
@@ -1124,25 +1161,29 @@ impl Node {
 
         let zvol = format!(
             "/dev/zvol/rdsk/{}/topo/{}/{}",
-            self.dataset, r.deployment.name, self.name,
+            self.dataset, deployment_name, self.name,
         );
 
         Ok(zvol)
     }
 
-    fn create_file_backing(&self, r: &Runner) -> Result<String, Error> {
+    fn create_file_backing(
+        &self,
+        log: &Logger,
+        deployment_name: &str,
+    ) -> Result<String, Error> {
         let size = format!("{}G", self.reserved);
 
-        let dir = format!("/var/falcon/dsk/{}", r.deployment.name);
+        let dir = format!("/var/falcon/dsk/{}", deployment_name);
         if let Err(e) = fs::create_dir_all(&dir) {
-            error!(r.log, "failed to create image directory: {e}");
+            error!(log, "failed to create image directory: {e}");
             return Err(Error::IO(e));
         }
         let backing = format!("{}/{}", dir, self.name);
         let source_zvol =
             format!("/dev/zvol/dsk/{}/img/{}@base", self.dataset, self.image);
 
-        info!(r.log, "copying backing image for {}", self.name);
+        info!(log, "copying backing image for {}", self.name);
         let dd_if = format!("if={source_zvol}");
         let dd_of = format!("of={backing}");
         let out = Command::new(DD_BIN)
@@ -1162,42 +1203,21 @@ impl Node {
         Ok(backing)
     }
 
-    fn create_blockdev(
-        &self,
-        backing: String,
-        devices: &mut BTreeMap<String, Device>,
-        block_devs: &mut BTreeMap<String, BlockDevice>,
-    ) {
-        let mut device_options = BTreeMap::new();
-        let mut blockdev_options = BTreeMap::new();
-        device_options.insert(
-            "block_dev".to_string(),
-            toml::Value::String("main_disk".to_string()),
+    fn create_blockdev(&mut self, backing: String) {
+        self.components.insert(
+            SpecKey::Name("main_disk".to_string()),
+            ComponentV0::VirtioDisk(VirtioDisk {
+                backend_id: SpecKey::Name("main_disk_backing".into()),
+                pci_path: PciPath::new(0, 4, 0).unwrap(),
+            }),
         );
-        device_options.insert(
-            "pci-path".to_string(),
-            toml::Value::String("0.4.0".to_string()),
-        );
-        devices.insert(
-            "block0".to_string(),
-            propolis_server_config::Device {
-                driver: "pci-virtio-block".to_string(),
-                options: device_options,
-            },
-        );
-        blockdev_options
-            .insert("path".to_string(), toml::Value::String(backing));
-        block_devs.insert(
-            "main_disk".to_string(),
-            propolis_server_config::BlockDevice {
-                bdtype: "file".to_string(),
-                options: blockdev_options,
-                opts: BlockOpts {
-                    block_size: None,
-                    read_only: None,
-                    skip_flush: Some(true),
-                },
-            },
+
+        self.components.insert(
+            SpecKey::Name("main_disk_backing".to_string()),
+            ComponentV0::FileStorageBackend(FileStorageBackend {
+                path: backing,
+                readonly: false,
+            }),
         );
     }
 
@@ -1205,9 +1225,15 @@ impl Node {
         // launch vm
 
         let id = uuid::Uuid::new_v4();
-        let port =
-            launch_vm(&r.log, &r.propolis_binary, &id, self, &r.falcon_dir)
-                .await?;
+        let port = launch_vm(
+            &r.log,
+            &r.propolis_binary,
+            &id,
+            self,
+            &r.falcon_dir,
+            Some(&self.components),
+        )
+        .await?;
 
         if !self.do_setup {
             return Ok(());
@@ -1466,28 +1492,35 @@ pub(crate) async fn launch_vm(
     id: &uuid::Uuid,
     node: &Node,
     falcon_dir: &Utf8Path,
+    components: Option<&BTreeMap<SpecKey, ComponentV0>>,
 ) -> Result<u16, Error> {
     // launch propolis-server
 
     let mut path = falcon_dir.to_path_buf();
+
     path.push(format!("{}.out", node.name));
     let stdout = fs::File::create(&path)?;
     path.pop();
+
     path.push(format!("{}.err", node.name));
     let stderr = fs::File::create(&path)?;
     path.pop();
-    path.push(format!("{}.toml", node.name));
-    let config = path.clone();
+
     let sockaddr = String::from("[::]:0");
     let mut cmd = Command::new(propolis_binary);
-    let mut args =
-        vec!["run".to_string(), config.into_string(), sockaddr.clone()];
+    let mut args = vec![
+        "run".to_string(),
+        "/var/ovmf/OVMF_CODE.fd".to_string(),
+        sockaddr.clone(),
+    ];
     if let Some(vnc_port) = node.vnc_port {
         args.push(format!("[::]:{}", vnc_port));
     }
-    cmd.args(&args).stdout(stdout).stderr(stderr);
+    cmd.args(&args)
+        .env("RUST_BACKTRACE", "FULL")
+        .stdout(stdout)
+        .stderr(stderr);
     let child = cmd.spawn()?;
-    path.pop();
 
     path.push(format!("{}.pid", node.name));
     fs::write(&path, child.id().to_string())?;
@@ -1531,10 +1564,6 @@ pub(crate) async fn launch_vm(
         id: *id,
         name: node.name.clone(),
         description: "a falcon vm".to_string(),
-        image_id: uuid::Uuid::default(),
-        bootrom_id: uuid::Uuid::default(),
-        memory: node.memory,
-        vcpus: node.cores,
         metadata: InstanceMetadata {
             project_id: uuid::Uuid::nil(),
             silo_id: uuid::Uuid::nil(),
@@ -1544,12 +1573,31 @@ pub(crate) async fn launch_vm(
             sled_revision: 0,
         },
     };
+
+    let spec = propolis_client::types::InstanceSpecV0 {
+        board: propolis_client::types::Board {
+            cpus: node.cores,
+            memory_mb: node.memory,
+            chipset: propolis_client::types::Chipset::I440Fx(
+                propolis_client::types::I440Fx { enable_pcie: false },
+            ),
+            cpuid: None,
+            guest_hv_interface: None,
+        },
+        components: if let Some(components) = components {
+            components
+                .iter()
+                .map(|(spec_key, comp)| (spec_key.to_string(), comp.clone()))
+                .collect()
+        } else {
+            Default::default()
+        },
+    };
     let req = propolis_client::types::InstanceEnsureRequest {
         properties,
-        nics: Vec::new(),
-        disks: Vec::new(),
-        migrate: None,
-        cloud_init_bytes: None,
+        init: propolis_client::types::InstanceInitializationMethod::Spec {
+            spec,
+        },
     };
 
     // we just launched the instance, so wait for it to become ready
@@ -1562,7 +1610,7 @@ pub(crate) async fn launch_vm(
                 break;
             }
             Err(e) => {
-                debug!(log, "instance ensure error: {e}, retry in 1 second");
+                warn!(log, "instance ensure error: {e}, retry in 1 second");
                 sleep(Duration::from_secs(1)).await;
                 continue;
             }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -786,10 +786,29 @@ impl Node {
     ) -> Result<(), Error> {
         self.try_ensure_base_image(log).await?;
 
+        // Propolis supports COM1 to COM4, so ensure those devices are present.
+        // Note COM4 will be added implicitly due to the presence of a
+        // SoftNpuPciPort device in the spec, and it will be commandeered by
+        // SoftNPU devices.
+
         self.components.insert(
             SpecKey::Name("com1".into()),
             ComponentV0::SerialPort(SerialPort {
                 num: SerialPortNumber::Com1,
+            }),
+        );
+
+        self.components.insert(
+            SpecKey::Name("com2".into()),
+            ComponentV0::SerialPort(SerialPort {
+                num: SerialPortNumber::Com2,
+            }),
+        );
+
+        self.components.insert(
+            SpecKey::Name("com3".into()),
+            ComponentV0::SerialPort(SerialPort {
+                num: SerialPortNumber::Com3,
             }),
         );
 


### PR DESCRIPTION
Update to use the latest propolis-server API: build an instance spec instead of the TOML file, and send that in the instance ensure.

Fixes #126