### PR TITLE
use buildomat artifact to download propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=ba4d338f0c98faa0328502c99aa6fa0e0948d3da#ba4d338f0c98faa0328502c99aa6fa0e0948d3da"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bdaaf207c7d7f9a6d905a3589eb8e159aa78df12#bdaaf207c7d7f9a6d905a3589eb8e159aa78df12"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -1573,7 +1573,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=ba4d338f0c98faa0328502c99aa6fa0e0948d3da#ba4d338f0c98faa0328502c99aa6fa0e0948d3da"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bdaaf207c7d7f9a6d905a3589eb8e159aa78df12#bdaaf207c7d7f9a6d905a3589eb8e159aa78df12"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=ba4d338f0c98faa0328502c99aa6fa0e0948d3da#ba4d338f0c98faa0328502c99aa6fa0e0948d3da"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bdaaf207c7d7f9a6d905a3589eb8e159aa78df12#bdaaf207c7d7f9a6d905a3589eb8e159aa78df12"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ slog = { version = "2.7", features = ["max_level_trace"] }
 slog-term = "2.7"
 slog-async = "2.7"
 slog-envlogger = "2.2"
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "ba4d338f0c98faa0328502c99aa6fa0e0948d3da" }
 toml = "0.8"
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "bdaaf207c7d7f9a6d905a3589eb8e159aa78df12" }
 libc = "0.2"
 tokio = { version = "1.44.2", features = ["full"] }
 tokio-tungstenite = "0.21"

--- a/get-propolis.sh
+++ b/get-propolis.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-# from propolis' `falcon` job, commit ba4d338f0c98faa0328502c99aa6fa0e0948d3da
-curl -OL https://buildomat.eng.oxide.computer/wg/0/artefact/01JQA00H3HQ2H7JW0PWMDQ7XDN/52rIztYQlpRJEttYOMaflSu2b8GnmLPUnW6TsjkChj37dvgp/01JQA00TDFWX2870391FPKBY76/01JQA0N556K971D0XGQPGJYVKJ/propolis-server
+# get propolis version from Cargo.toml
+rev=`cat Cargo.toml | grep propolis | sed -E 's/.*rev = "([^"]+)".*/\1/'`
+echo "Fetching propolis version $rev"
+
+curl -OL https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/falcon/$rev/propolis-server
 chmod +x propolis-server
 pfexec mv propolis-server /usr/bin/


### PR DESCRIPTION
Fixes
- #134 

Also ensures that propolis download stays consistent with Cargo dependencies by grabbing propolis rev from Cargo.toml