### PR TITLE
Fix improper string formatting for propolis bin

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -333,7 +333,7 @@ impl Runner {
     pub fn get_propolis_binary(&self) -> String {
         match self.custom_propolis_binary {
             None => format!(
-                "{}/DEFAULT_PROPOLIS_RELATIVE_PATH",
+                "{}/{DEFAULT_PROPOLIS_RELATIVE_PATH}",
                 self.get_falcon_dir()
             ),
             Some(ref bin) => String::from(bin),


### PR DESCRIPTION
get_propolis_binary() was intended to format a const into the returned string.  Instead, it was using the const var's name as a literal. Let's fix that.