### PR TITLE
Ensure images are downloaded and created atomically

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1145,6 +1145,7 @@ impl Node {
         from: &str,
         to: &str,
     ) -> Result<usize, Error> {
+        let tmp = format!("{to}.tmp");
         if Path::new(to).exists() {
             info!(log, "image already extracted");
             let file = std::fs::File::open(to)?;
@@ -1165,9 +1166,12 @@ impl Node {
         pb.inc_length(len);
         let in_file = pb.wrap_read(in_file);
         let mut dec = XzDecoder::new(in_file);
-        let mut outfile = std::fs::File::create(to)?;
+        let mut outfile = std::fs::File::create(&tmp)?;
         std::io::copy(&mut dec, &mut outfile)?;
         pb.finish();
+
+        std::fs::rename(tmp, to).context("rename to final image")?;
+
         Ok(outfile
             .metadata()
             .context("get file metadata")?


### PR DESCRIPTION
I ran into an issue trying to get a4x2 running where the download of the Arista image stalled.  Aborting and restarting `a4x2 launch` caused it to try to extract the partially downloaded image.

I'm pretty sure this is correct but I'm still working on getting a4x2 to build using this branch to verify it works as expected.