### PR TITLE
Allow configuring model and serial number per node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=3f1752e6cee9a2f8ecdce6e2ad3326781182e2d9#3f1752e6cee9a2f8ecdce6e2ad3326781182e2d9"
+source = "git+https://github.com/oxidecomputer/propolis?rev=9d82bd4fb3e5840c8c8f506d7016dcc7cf3eb52c#9d82bd4fb3e5840c8c8f506d7016dcc7cf3eb52c"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -1469,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=3f1752e6cee9a2f8ecdce6e2ad3326781182e2d9#3f1752e6cee9a2f8ecdce6e2ad3326781182e2d9"
+source = "git+https://github.com/oxidecomputer/propolis?rev=9d82bd4fb3e5840c8c8f506d7016dcc7cf3eb52c#9d82bd4fb3e5840c8c8f506d7016dcc7cf3eb52c"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=3f1752e6cee9a2f8ecdce6e2ad3326781182e2d9#3f1752e6cee9a2f8ecdce6e2ad3326781182e2d9"
+source = "git+https://github.com/oxidecomputer/propolis?rev=9d82bd4fb3e5840c8c8f506d7016dcc7cf3eb52c#9d82bd4fb3e5840c8c8f506d7016dcc7cf3eb52c"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ slog-term = "2.7"
 slog-async = "2.7"
 slog-envlogger = "2.2"
 toml = "0.9"
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "3f1752e6cee9a2f8ecdce6e2ad3326781182e2d9" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "9d82bd4fb3e5840c8c8f506d7016dcc7cf3eb52c" }
 libc = "0.2"
 tokio = { version = "1.48.0", features = ["full"] }
 tokio-tungstenite = "0.21"


### PR DESCRIPTION
This is primarily useful in a4x2 to populate the smbios with information that matches the platform id of certificates used by sprockets.