### PR TITLE
box some error variants to reduce stack size

### DIFF
--- a/examples/duo/src/main.rs
+++ b/examples/duo/src/main.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![allow(clippy::result_large_err)]
-
 // Copyright 2022 Oxide Computer Company
 
 use libfalcon::{cli::run, error::Error, unit::gb, Runner};

--- a/examples/helios-dev/src/main.rs
+++ b/examples/helios-dev/src/main.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![allow(clippy::result_large_err)]
-
 // Copyright 2022 Oxide Computer Company
 
 use libfalcon::{cli::run, error::Error, unit::gb, Runner};

--- a/examples/solo/src/main.rs
+++ b/examples/solo/src/main.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![allow(clippy::result_large_err)]
-
 // Copyright 2022 Oxide Computer Company
 use libfalcon::{cli::run, error::Error, unit::gb, Runner};
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -39,13 +39,13 @@ pub enum Error {
     Ron(#[from] ron::Error),
     TomL(#[from] toml::ser::Error),
     AddrParse(#[from] std::net::AddrParseError),
-    Propolis(#[from] propolis_client::Error),
+    Propolis(#[source] Box<propolis_client::Error>),
     PropolisTypes(
-        #[from] propolis_client::Error<propolis_client::types::Error>,
+        #[source] Box<propolis_client::Error<propolis_client::types::Error>>,
     ),
     IntParse(#[from] std::num::ParseIntError),
     TryIntParse(#[from] std::num::TryFromIntError),
-    WsError(#[from] tokio_tungstenite::tungstenite::Error),
+    WsError(#[source] Box<tokio_tungstenite::tungstenite::Error>),
     Anyhow(#[from] anyhow::Error),
     Uuid(#[from] uuid::Error),
     #[error("no ports available")]
@@ -53,4 +53,24 @@ pub enum Error {
     Zfs(String),
     #[error("default route has no interface")]
     NoInterfaceForDefaultRoute,
+}
+
+impl From<propolis_client::Error> for Error {
+    fn from(error: propolis_client::Error) -> Self {
+        Self::Propolis(Box::new(error))
+    }
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for Error {
+    fn from(error: tokio_tungstenite::tungstenite::Error) -> Self {
+        Self::WsError(Box::new(error))
+    }
+}
+
+impl From<propolis_client::Error<propolis_client::types::Error>> for Error {
+    fn from(
+        error: propolis_client::Error<propolis_client::types::Error>,
+    ) -> Self {
+        Self::PropolisTypes(Box::new(error))
+    }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![allow(clippy::result_large_err)]
-
 // Copyright 2022 Oxide Computer Company
 
 #[cfg(test)]


### PR DESCRIPTION
Some downstream consumers (e.g. maghemite's falcon-lab) are complaining because of build errors coming from libfalcon error's being rather large and utilizing a lot of stack memory (176+ bytes). This boxes the largest three variants and removes the clippy bypasses for large results.